### PR TITLE
Remove demo execution block from model

### DIFF
--- a/inference/model.py
+++ b/inference/model.py
@@ -791,11 +791,14 @@ class Transformer(nn.Module):
         return logits
 
 
-if __name__ == "__main__":
-    torch.set_default_dtype(torch.bfloat16)
-    torch.set_default_device("cuda")
-    torch.manual_seed(0)
-    args = ModelArgs()
-    x = torch.randint(0, args.vocab_size, (2, 128))
-    model = Transformer(args)
-    print(model(x).size())
+# The following block ran a quick demo when this module was executed as a
+# script. It has been commented out to avoid unintended execution during
+# imports or automated environments.
+# if __name__ == "__main__":
+#     torch.set_default_dtype(torch.bfloat16)
+#     torch.set_default_device("cuda")
+#     torch.manual_seed(0)
+#     args = ModelArgs()
+#     x = torch.randint(0, args.vocab_size, (2, 128))
+#     model = Transformer(args)
+#     print(model(x).size())


### PR DESCRIPTION
## Summary
- comment out the `__main__` demo code in `inference/model.py` to avoid auto-execution when imported

## Testing
- `python -m py_compile inference/model.py`

------
https://chatgpt.com/codex/tasks/task_e_6872dd1abcf48329af48a2573416adae