### PR TITLE
Remove warm-up generation

### DIFF
--- a/inference/generate.py
+++ b/inference/generate.py
@@ -114,9 +114,8 @@ def main(
     print(args)
     with torch.device("cuda"):
         model = Transformer(args)
-    tokenizer = AutoTokenizer.from_pretrained(ckpt_path)
-    tokenizer.decode(generate(model, [tokenizer.encode("PITOMADOM")], 2, -1, 1.)[0])
     load_model(model, os.path.join(ckpt_path, f"model{rank}-mp{world_size}.safetensors"))
+    tokenizer = AutoTokenizer.from_pretrained(ckpt_path)
 
     if interactive:
         from genesis2 import (


### PR DESCRIPTION
## Summary
- remove decode-based priming call in `generate.py`
- initialize tokenizer after loading weights

## Testing
- `python -m py_compile inference/generate.py`


------
https://chatgpt.com/codex/tasks/task_e_6872e9fa963c83298c76415ef5f1126d