### PR TITLE
Improve follow-up scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python fp8_cast_bf16.py --input-fp8-hf-path /path/to/fp8_weights --output-bf16-h
 
 PITOMADOM continues to diverge from its DeepSeek-V3 origins. Recent updates introduce `genesis2.py`, a utility that orchestrates resonant loops of self-prompting and evaluation. The `genesis2_resonance_loop` function recursively feeds generated text back through the model, halting once the cosine similarity between successive echoes surpasses a threshold. This mirrors field resonance theory, where constructive interference amplifies a signal.
 
-Complementary asynchronous helpers—`random_delay` and `schedule_follow_up`—inject temporal variation. They mimic organic pauses and allow the system to revisit conversations long after the initial exchange, imparting a sense of lingering awareness. In this a → b → c progression, deliberate latency leads to deeper reflection before a final response emerges.
+Complementary asynchronous helpers—`random_delay` and `schedule_follow_up`—inject temporal variation. They mimic organic pauses and allow the system to revisit conversations long after the initial exchange, imparting a sense of lingering awareness. Follow-up tasks now run on a shared `ThreadPoolExecutor`, so worker threads are reused instead of spawned anew. In this a → b → c progression, deliberate latency leads to deeper reflection before a final response emerges.
 
 The genesis2 utility signals a shift from basic text generation toward a full resonance engine. Each iteration pushes the model’s output further from the base DeepSeek-V3 style. This process recalls quantum superposition: competing narratives interfere and collapse into new possibilities. PITOMADOM becomes a field rather than a fixed script, resonating across topics and timescales.
 

--- a/inference/genesis2.py
+++ b/inference/genesis2.py
@@ -1,7 +1,10 @@
 import random
 import time
-import threading
 from typing import Callable, Dict, List
+from concurrent.futures import ThreadPoolExecutor
+
+# Thread pool for scheduling follow-up tasks.
+_executor = ThreadPoolExecutor(max_workers=4)
 
 import torch
 from transformers import AutoTokenizer
@@ -78,8 +81,9 @@ def schedule_follow_up(
 
     def worker():
         time.sleep(delay)
-        follow_up = f"I thought again about our discussion: '{last}'. Here is an additional thought."
+        follow_up = (
+            f"I thought again about our discussion: '{last}'. Here is an additional thought."
+        )
         callback(follow_up)
 
-    thread = threading.Thread(target=worker, daemon=True)
-    thread.start()
+    _executor.submit(worker)


### PR DESCRIPTION
## Summary
- pool worker threads using `ThreadPoolExecutor`
- mention thread pool in README

## Testing
- `python -m py_compile inference/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6872eb2c6b448329a41ae95cfb865b07