### PR TITLE
Add model license and reference in README

### DIFF
--- a/LICENSE-MODEL
+++ b/LICENSE-MODEL
@@ -1,0 +1,13 @@
+PITOMADOM Model License
+=======================
+
+The PITOMADOM weights and configuration files ("Model") may be used, modified, and
+redistributed, including for commercial purposes, provided that:
+
+1. Any use complies with applicable laws and regulations.
+2. You do not use the Model to deliberately produce or facilitate harm, including
+   but not limited to generating malicious code or misinformation.
+3. Any redistribution of the Model must retain this license file.
+
+THE MODEL IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND. THE AUTHORS SHALL
+NOT BE LIABLE FOR ANY CLAIM OR DAMAGES ARISING FROM USE OF THE MODEL.

--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ flake8
 
 ## License
 
-Code is released under the MIT License. Model use is governed by the accompanying Model License.
+Code is released under the MIT License. Model use is governed by the accompanying Model License (see LICENSE-MODEL).


### PR DESCRIPTION
## Summary
- provide `LICENSE-MODEL` describing usage terms for the weights
- update README license section with a link to the new file

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730cae6be88329ae85b0902616b58b