### PR TITLE
Fix shutdown executor test

### DIFF
--- a/tests/test_genesis2.py
+++ b/tests/test_genesis2.py
@@ -103,7 +103,7 @@ def test_random_delay(monkeypatch, genesis2):
     assert called == [1]
 
 
-def test_shutdown_executor(monkeypatch):
+def test_shutdown_executor(monkeypatch, genesis2):
     calls = []
 
     class DummyExecutor:


### PR DESCRIPTION
## Summary
- pass the `genesis2` fixture to `test_shutdown_executor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873195978ec8329a8ea1ad971da782b